### PR TITLE
Create campaign landing page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,615 @@
+:root {
+    --color-primary: #0b4f6c;
+    --color-secondary: #f4a259;
+    --color-accent: #2e86ab;
+    --color-background: #f6f7fb;
+    --color-text: #1b1b1f;
+    --color-muted: #5c6370;
+    --color-white: #ffffff;
+    --font-heading: 'Playfair Display', serif;
+    --font-body: 'Work Sans', sans-serif;
+    --shadow-soft: 0 20px 40px rgba(11, 79, 108, 0.12);
+    --shadow-card: 0 12px 30px rgba(11, 79, 108, 0.1);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-body);
+    color: var(--color-text);
+    background-color: var(--color-background);
+    line-height: 1.6;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--color-accent);
+}
+
+.container {
+    width: min(1120px, 90vw);
+    margin: 0 auto;
+}
+
+.section {
+    padding: 6rem 0;
+}
+
+h1, h2, h3, h4 {
+    font-family: var(--font-heading);
+    margin-top: 0;
+    color: var(--color-primary);
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    font-weight: 600;
+    border: 2px solid transparent;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button.primary {
+    background: var(--color-primary);
+    color: var(--color-white);
+    box-shadow: var(--shadow-soft);
+}
+
+.button.primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(11, 79, 108, 0.25);
+}
+
+.button.secondary {
+    background: var(--color-white);
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+}
+
+.button.secondary:hover {
+    background: rgba(11, 79, 108, 0.08);
+}
+
+.button.tertiary {
+    color: var(--color-secondary);
+    border-color: transparent;
+    padding-left: 0;
+}
+
+.button.tertiary::after {
+    content: '→';
+    margin-left: 0.75rem;
+    transition: transform 0.2s ease;
+}
+
+.button.tertiary:hover::after {
+    transform: translateX(4px);
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: rgba(246, 247, 251, 0.95);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(11, 79, 108, 0.08);
+    transition: box-shadow 0.2s ease;
+}
+
+.site-header.scrolled {
+    box-shadow: 0 12px 24px rgba(11, 79, 108, 0.12);
+}
+
+.site-header .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 0;
+}
+
+.branding {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.branding .monogram {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-white);
+    font-family: var(--font-heading);
+    font-weight: 600;
+    letter-spacing: 1px;
+}
+
+.brand-text .subtitle {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--color-muted);
+}
+
+.brand-text h1,
+.brand-text h2 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.main-nav {
+    position: relative;
+}
+
+.main-nav ul {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.main-nav a {
+    font-weight: 500;
+}
+
+.nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+}
+
+.hero {
+    background: radial-gradient(circle at top left, rgba(14, 107, 144, 0.18), transparent 55%),
+                linear-gradient(120deg, rgba(244, 162, 89, 0.18), transparent 50%);
+    padding-top: 8rem;
+}
+
+.hero-content {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3rem;
+    align-items: center;
+}
+
+.hero-copy h2 {
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    margin-bottom: 1rem;
+}
+
+.hero-copy p {
+    font-size: 1.05rem;
+    color: var(--color-muted);
+}
+
+.hero-actions {
+    margin-top: 2rem;
+    display: flex;
+    gap: 1rem;
+}
+
+.hero-card {
+    background: var(--color-white);
+    border-radius: 28px;
+    padding: 2rem;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.hero-portrait {
+    height: 280px;
+    border-radius: 22px;
+    background: linear-gradient(135deg, rgba(11, 79, 108, 0.9), rgba(46, 134, 171, 0.5)),
+                url('https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=800&q=80');
+    background-size: cover;
+    background-position: center;
+}
+
+.hero-statement .quote {
+    font-style: italic;
+    color: var(--color-muted);
+    margin: 0;
+}
+
+.hero-statement .signature {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.section-grid {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: 2fr 1fr;
+    align-items: start;
+}
+
+.highlight-list {
+    list-style: none;
+    padding: 0;
+    margin: 2rem 0 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.highlight-list li {
+    background: var(--color-white);
+    padding: 1.2rem 1.4rem;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+}
+
+.recognitions {
+    background: var(--color-white);
+    padding: 2rem;
+    border-radius: 20px;
+    box-shadow: var(--shadow-card);
+}
+
+.recognitions h3 {
+    margin-bottom: 1rem;
+}
+
+.recognitions ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.proposals h2 {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.proposal-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.75rem;
+}
+
+.proposal-card {
+    background: var(--color-white);
+    padding: 2rem;
+    border-radius: 20px;
+    box-shadow: var(--shadow-card);
+    border-top: 6px solid rgba(244, 162, 89, 0.4);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.proposal-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 18px 36px rgba(11, 79, 108, 0.16);
+}
+
+.focus-areas {
+    background: linear-gradient(135deg, rgba(11, 79, 108, 0.08), rgba(46, 134, 171, 0.08));
+}
+
+.focus-grid {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: 1.2fr 1fr;
+    align-items: center;
+}
+
+.pillars {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.pillar {
+    background: var(--color-white);
+    border-radius: 18px;
+    padding: 1.5rem;
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+    box-shadow: var(--shadow-card);
+}
+
+.pillar-number {
+    font-size: 2rem;
+    font-family: var(--font-heading);
+    color: var(--color-accent);
+}
+
+.timeline {
+    position: relative;
+    margin-top: 3rem;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 12px;
+    width: 4px;
+    height: 100%;
+    background: linear-gradient(180deg, var(--color-primary), rgba(11, 79, 108, 0.1));
+}
+
+.timeline-item {
+    position: relative;
+    padding-left: 3rem;
+}
+
+.timeline-date {
+    position: absolute;
+    left: 0;
+    top: 0.25rem;
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    background: var(--color-white);
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    color: var(--color-primary);
+    box-shadow: var(--shadow-card);
+}
+
+.timeline-content {
+    background: var(--color-white);
+    padding: 1.5rem;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+}
+
+.news h2 {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.news-grid {
+    display: grid;
+    gap: 1.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.news-card {
+    background: var(--color-white);
+    padding: 2rem;
+    border-radius: 20px;
+    box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.news-date {
+    font-weight: 600;
+    color: var(--color-secondary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.news-link {
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.testimonials h2 {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.testimonial-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonial {
+    background: var(--color-white);
+    padding: 2rem;
+    border-radius: 20px;
+    box-shadow: var(--shadow-card);
+}
+
+.testimonial blockquote {
+    margin: 0 0 1rem;
+    font-style: italic;
+    color: var(--color-muted);
+}
+
+.cta {
+    background: linear-gradient(135deg, rgba(11, 79, 108, 0.92), rgba(46, 134, 171, 0.86));
+    color: var(--color-white);
+}
+
+.cta h2 {
+    color: var(--color-white);
+}
+
+.cta p {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.cta-form {
+    margin-top: 2rem;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.form-group label {
+    font-weight: 600;
+}
+
+.form-group input {
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    border: none;
+    font: inherit;
+}
+
+.cta .button {
+    justify-self: start;
+}
+
+.site-footer {
+    background: #0a2f41;
+    color: rgba(255, 255, 255, 0.88);
+    padding-top: 3rem;
+}
+
+.site-footer h2,
+.site-footer h3 {
+    color: var(--color-white);
+}
+
+.footer-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    padding-bottom: 3rem;
+}
+
+.footer-note {
+    margin-top: 1rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.footer-links ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.footer-links a {
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.social-links {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.social-links a {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    transition: background 0.2s ease;
+}
+
+.social-links a:hover {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    padding: 1.5rem 0;
+    text-align: center;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 900px) {
+    .hero-content,
+    .section-grid,
+    .focus-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .hero-card {
+        order: -1;
+    }
+}
+
+@media (max-width: 768px) {
+    .site-header .container {
+        flex-wrap: wrap;
+    }
+
+    .main-nav ul {
+        position: absolute;
+        top: 100%;
+        right: 0;
+        background: var(--color-white);
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 1rem 1.5rem;
+        border-radius: 18px;
+        box-shadow: var(--shadow-card);
+        transform-origin: top right;
+        transform: scaleY(0);
+        opacity: 0;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+    }
+
+    .main-nav ul.open {
+        transform: scaleY(1);
+        opacity: 1;
+    }
+
+    .main-nav .button {
+        width: 100%;
+    }
+
+    .nav-toggle {
+        display: block;
+    }
+}
+
+@media (max-width: 600px) {
+    .section {
+        padding: 4rem 0;
+    }
+
+    .site-header .container {
+        padding: 1rem;
+    }
+
+    .hero {
+        padding-top: 6rem;
+    }
+
+    .hero-card,
+    .proposal-card,
+    .testimonial,
+    .recognitions,
+    .timeline-content {
+        padding: 1.5rem;
+    }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,34 @@
+const navToggle = document.querySelector('.nav-toggle');
+const navMenu = document.querySelector('.main-nav ul');
+
+if (navToggle && navMenu) {
+    navToggle.addEventListener('click', () => {
+        const isOpen = navMenu.classList.toggle('open');
+        navToggle.setAttribute('aria-expanded', String(isOpen));
+    });
+}
+
+const header = document.querySelector('.site-header');
+if (header) {
+    const observer = new IntersectionObserver(
+        ([entry]) => {
+            if (!entry.isIntersecting) {
+                header.classList.add('scrolled');
+            } else {
+                header.classList.remove('scrolled');
+            }
+        },
+        { threshold: 0.1 }
+    );
+
+    observer.observe(document.querySelector('.hero'));
+}
+
+const form = document.querySelector('.cta-form');
+if (form) {
+    form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        alert('¡Gracias por sumarte! Pronto nos pondremos en contacto.');
+        form.reset();
+    });
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jeanette Bonilla Freire | Candidata a Rectora UG</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Work+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <header class="site-header" id="inicio">
+        <div class="container">
+            <div class="branding">
+                <div class="monogram">JB</div>
+                <div class="brand-text">
+                    <span class="subtitle">Candidata a Rectora</span>
+                    <h1>Jeanette Bonilla Freire</h1>
+                </div>
+            </div>
+            <nav class="main-nav" aria-label="Navegación principal">
+                <button class="nav-toggle" aria-expanded="false" aria-controls="navigation-menu">☰</button>
+                <ul id="navigation-menu">
+                    <li><a href="#inicio">Inicio</a></li>
+                    <li><a href="#trayectoria">Trayectoria</a></li>
+                    <li><a href="#propuestas">Propuestas</a></li>
+                    <li><a href="#agenda">Agenda</a></li>
+                    <li><a href="#noticias">Noticias</a></li>
+                    <li><a href="#sumate" class="button">Súmate</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero" aria-labelledby="hero-title">
+            <div class="container hero-content">
+                <div class="hero-copy">
+                    <h2 id="hero-title">Innovar para transformar la Universidad de Guayaquil</h2>
+                    <p>Con más de 25 años de servicio a la comunidad universitaria, Jeanette Bonilla Freire propone una universidad transparente, inclusiva e internacionalizada, preparada para los desafíos del futuro.</p>
+                    <div class="hero-actions">
+                        <a href="#propuestas" class="button primary">Conoce la visión</a>
+                        <a href="#sumate" class="button secondary">Únete al equipo</a>
+                    </div>
+                </div>
+                <div class="hero-card" role="presentation">
+                    <div class="hero-portrait" aria-hidden="true"></div>
+                    <div class="hero-statement">
+                        <p class="quote">“La excelencia académica y el compromiso social deben ir de la mano. Hagamos de la Universidad de Guayaquil un referente nacional e internacional.”</p>
+                        <span class="signature">Jeanette Bonilla Freire</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="trayectoria" class="trayectoria section" aria-labelledby="trayectoria-title">
+            <div class="container section-grid">
+                <div>
+                    <h2 id="trayectoria-title">Trayectoria académica y gestión</h2>
+                    <p>La trayectoria de Jeanette Bonilla Freire está marcada por la excelencia académica y el liderazgo en procesos de modernización institucional. Ha sido decana, investigadora y promotora de proyectos que acercan la universidad a la sociedad.</p>
+                    <ul class="highlight-list">
+                        <li><strong>Doctora en Administración Educativa</strong> por la Universidad de Guayaquil.</li>
+                        <li><strong>Ex Decana de la Facultad de Ciencias Administrativas</strong> impulsando la acreditación internacional.</li>
+                        <li><strong>Coordinadora de Innovación Académica</strong> liderando programas de digitalización y formación docente.</li>
+                        <li><strong>Investigadora y autora</strong> de publicaciones sobre gestión universitaria y responsabilidad social.</li>
+                    </ul>
+                </div>
+                <aside class="recognitions" aria-label="Logros destacados">
+                    <h3>Reconocimientos</h3>
+                    <ul>
+                        <li>Premio a la Excelencia Educativa, SENESCYT (2019)</li>
+                        <li>Mención Honorífica en Gestión Universitaria, Universidad de Cuenca (2021)</li>
+                        <li>Distinción Mujer Líder en la Academia, Cámara de Comercio de Guayaquil (2022)</li>
+                    </ul>
+                </aside>
+            </div>
+        </section>
+
+        <section id="propuestas" class="proposals section" aria-labelledby="propuestas-title">
+            <div class="container">
+                <h2 id="propuestas-title">Propuestas para la Universidad de Guayaquil</h2>
+                <div class="proposal-grid">
+                    <article class="proposal-card">
+                        <h3>Excelencia Académica</h3>
+                        <p>Fortalecer la calidad docente mediante programas continuos de capacitación, acreditación internacional y actualización curricular orientada a la investigación aplicada.</p>
+                    </article>
+                    <article class="proposal-card">
+                        <h3>Universidad Digital</h3>
+                        <p>Implementar plataformas tecnológicas para la gestión académica, laboratorios virtuales y recursos digitales accesibles que potencien la experiencia estudiantil.</p>
+                    </article>
+                    <article class="proposal-card">
+                        <h3>Inclusión y Bienestar</h3>
+                        <p>Garantizar programas de becas, acompañamiento psicosocial y espacios seguros e inclusivos que fomenten la permanencia estudiantil.</p>
+                    </article>
+                    <article class="proposal-card">
+                        <h3>Vinculación y Empleabilidad</h3>
+                        <p>Ampliar convenios con empresas y organizaciones sociales para prácticas pre profesionales, investigación aplicada y emprendimientos universitarios.</p>
+                    </article>
+                    <article class="proposal-card">
+                        <h3>Sostenibilidad y Gobernanza</h3>
+                        <p>Impulsar una gestión transparente con datos abiertos, participación estudiantil y políticas ambientales que reduzcan la huella de carbono.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="focus-areas section" aria-labelledby="focus-title">
+            <div class="container focus-grid">
+                <div>
+                    <h2 id="focus-title">Ejes estratégicos</h2>
+                    <p>La propuesta se articula en ejes de transformación que integran tecnología, investigación, internacionalización y bienestar. Cada eje incluye indicadores medibles para asegurar resultados concretos y evaluables.</p>
+                    <a href="#sumate" class="button tertiary">Descarga el plan completo</a>
+                </div>
+                <div class="pillars">
+                    <div class="pillar">
+                        <span class="pillar-number">01</span>
+                        <div>
+                            <h3>Campus Inteligente</h3>
+                            <p>Infraestructura conectada, sistemas de seguridad inteligentes y servicios estudiantiles digitalizados.</p>
+                        </div>
+                    </div>
+                    <div class="pillar">
+                        <span class="pillar-number">02</span>
+                        <div>
+                            <h3>Investigación con impacto</h3>
+                            <p>Fondos competitivos, incubadoras de proyectos y alianzas con centros científicos internacionales.</p>
+                        </div>
+                    </div>
+                    <div class="pillar">
+                        <span class="pillar-number">03</span>
+                        <div>
+                            <h3>Proyección Social</h3>
+                            <p>Programas que articulan a la universidad con los territorios y atienden desafíos locales.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="agenda" class="agenda section" aria-labelledby="agenda-title">
+            <div class="container">
+                <h2 id="agenda-title">Agenda pública</h2>
+                <div class="timeline">
+                    <div class="timeline-item">
+                        <div class="timeline-date">15 Abr</div>
+                        <div class="timeline-content">
+                            <h3>Foro de Innovación Educativa</h3>
+                            <p>Encuentro con docentes e investigadores para dialogar sobre la transformación curricular y los entornos digitales.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-date">20 Abr</div>
+                        <div class="timeline-content">
+                            <h3>Diálogo con estudiantes</h3>
+                            <p>Conversatorio abierto para recoger propuestas sobre bienestar, movilidad y participación estudiantil.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-date">28 Abr</div>
+                        <div class="timeline-content">
+                            <h3>Visita a facultades</h3>
+                            <p>Recorrido por los campus para presentar el plan de trabajo y escuchar a la comunidad universitaria.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="noticias" class="news section" aria-labelledby="news-title">
+            <div class="container">
+                <h2 id="news-title">Noticias y artículos</h2>
+                <div class="news-grid">
+                    <article class="news-card">
+                        <span class="news-date">05 Abril 2024</span>
+                        <h3>Jeanette Bonilla presenta el plan Universidad 2030</h3>
+                        <p>Durante una rueda de prensa, la candidata anunció los pilares estratégicos para modernizar la institución en la próxima década.</p>
+                        <a href="#" class="news-link">Leer más</a>
+                    </article>
+                    <article class="news-card">
+                        <span class="news-date">30 Marzo 2024</span>
+                        <h3>Encuentro con graduados</h3>
+                        <p>La comunidad alumni compartió experiencias y aportes para fortalecer la empleabilidad y la innovación.</p>
+                        <a href="#" class="news-link">Leer más</a>
+                    </article>
+                    <article class="news-card">
+                        <span class="news-date">18 Marzo 2024</span>
+                        <h3>Programa de becas con enfoque de género</h3>
+                        <p>Se presentó una propuesta para ampliar las becas destinadas a mujeres en carreras STEM y emprendimientos.</p>
+                        <a href="#" class="news-link">Leer más</a>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="testimonials section" aria-labelledby="testimonials-title">
+            <div class="container">
+                <h2 id="testimonials-title">Voces de la comunidad</h2>
+                <div class="testimonial-grid">
+                    <figure class="testimonial">
+                        <blockquote>“La visión de Jeanette Bonilla pone en el centro a los estudiantes. Sus propuestas son concretas y con indicadores claros.”</blockquote>
+                        <figcaption>María Álvarez, representante estudiantil</figcaption>
+                    </figure>
+                    <figure class="testimonial">
+                        <blockquote>“Con Jeanette hemos trabajado en proyectos de innovación que ahora son un referente. Su liderazgo es colaborativo.”</blockquote>
+                        <figcaption>Dr. Carlos Herrera, investigador UG</figcaption>
+                    </figure>
+                    <figure class="testimonial">
+                        <blockquote>“Es una gestora transparente, siempre abierta a rendir cuentas y a escuchar a la comunidad.”</blockquote>
+                        <figcaption>Lucía Benítez, docente</figcaption>
+                    </figure>
+                </div>
+            </div>
+        </section>
+
+        <section id="sumate" class="cta section" aria-labelledby="cta-title">
+            <div class="container">
+                <div class="cta-content">
+                    <h2 id="cta-title">Súmate al equipo de Jeanette Bonilla</h2>
+                    <p>Construyamos juntas y juntos la universidad que soñamos: innovadora, transparente y cercana. Regístrate para recibir información, participar en encuentros y sumar tus ideas.</p>
+                    <form class="cta-form">
+                        <div class="form-group">
+                            <label for="name">Nombre completo</label>
+                            <input type="text" id="name" name="name" placeholder="Tu nombre" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="email">Correo electrónico</label>
+                            <input type="email" id="email" name="email" placeholder="tu@correo.com" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="faculty">Facultad</label>
+                            <input type="text" id="faculty" name="faculty" placeholder="Facultad">
+                        </div>
+                        <button type="submit" class="button primary">Quiero participar</button>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer" aria-label="Pie de página">
+        <div class="container footer-grid">
+            <div>
+                <div class="branding footer-branding">
+                    <div class="monogram">JB</div>
+                    <div class="brand-text">
+                        <span class="subtitle">Candidata a Rectora</span>
+                        <h2>Jeanette Bonilla Freire</h2>
+                    </div>
+                </div>
+                <p class="footer-note">Compromiso con la excelencia académica, la innovación y la transparencia en la Universidad de Guayaquil.</p>
+            </div>
+            <div class="footer-links">
+                <h3>Contacto</h3>
+                <ul>
+                    <li><a href="mailto:contacto@jeanettebonilla.ec">contacto@jeanettebonilla.ec</a></li>
+                    <li><a href="tel:+59342345678">+593 4 234 5678</a></li>
+                </ul>
+                <div class="social-links" aria-label="Redes sociales">
+                    <a href="#" aria-label="Facebook">Fb</a>
+                    <a href="#" aria-label="Instagram">Ig</a>
+                    <a href="#" aria-label="Twitter">X</a>
+                    <a href="#" aria-label="YouTube">Yt</a>
+                </div>
+            </div>
+            <div class="footer-links">
+                <h3>Documentos</h3>
+                <ul>
+                    <li><a href="#">Plan de gestión</a></li>
+                    <li><a href="#">Código de ética</a></li>
+                    <li><a href="#">Informe de transparencia</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <div class="container">
+                <p>© 2024 Comité de Campaña Jeanette Bonilla Freire. Todos los derechos reservados.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a single-page campaign site for Jeanette Bonilla Freire with sections for trayectoria, propuestas, agenda y noticias
- add responsive styling, typography, and gradient accents inspired by contemporary academic campaign sites
- implement simple navigation toggle, sticky header effect, and form submission acknowledgement in JavaScript

## Testing
- Not Run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e5b5c30ef483268f4625939ed3c6a0